### PR TITLE
ci(workflow): add timeouts for running jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
           echo "::set-output name=config::[${CONFIG}]"
 
   make-docker-images:
+    timeout-minutes: 10
     runs-on: ubuntu-20.04
     needs: prepare
     strategy:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,7 @@ jobs:
           echo "::set-output name=config::[${CONFIG}]"
 
   publish-docker-images:
+    timeout-minutes: 10
     runs-on: ubuntu-20.04
     needs: prepare
     strategy:


### PR DESCRIPTION
Limit the time spent to run the jobs: `make-docker-images`, `publish-docker-images`.