### PR TITLE
feat: add ruby-rdf docker image

### DIFF
--- a/dockerfiles/ruby-rdf/3.1.15/Dockerfile
+++ b/dockerfiles/ruby-rdf/3.1.15/Dockerfile
@@ -1,0 +1,12 @@
+FROM ruby:3.0.2-alpine3.14
+
+RUN gem install          \
+      rdf:3.1.15         \
+      rdf-turtle:3.1.3   \
+      rdf-n3:3.1.2       \
+      rdf-json:3.1.0     \ 
+      rdf-rdfxml:3.1.1   \
+      json-ld:3.1.10     \
+      sparql:3.1.8
+
+ENTRYPOINT ["rdf"]

--- a/dockerfiles/ruby-rdf/README.md
+++ b/dockerfiles/ruby-rdf/README.md
@@ -1,0 +1,57 @@
+# RDF: Linked Data for Ruby
+
+> `RDF` shell script which acts as a wrapper to perform a number of different operations on RDF files using available readers and writers.
+
+See: <https://github.com/ruby-rdf/rdf>
+
+## Available formats
+
+Image contains the following formats pre-installed to play with [RDF](https://www.w3.org/RDF/):
+
+- `jsonld`
+- `n3`
+- `nquads`
+- `ntriples`
+- `rdfa`
+- `rdfxml`
+- `turtle`
+- `vocabulary`
+
+Provided by the following extensions:
+
+- [RDF::Turtle](https://github.com/ruby-rdf/rdf-turtle)
+- [RDF::N3](https://github.com/ruby-rdf/rdf-n3)
+- [RDF::JSON](https://github.com/ruby-rdf/rdf-json)
+- [RDF:XML](https://github.com/ruby-rdf/rdf-rdfxml)
+- [JSON::LD](https://github.com/ruby-rdf/json-ld)
+
+## Usage
+
+The dockerfile simply exposes the [rdf](https://github.com/ruby-rdf/rdf#command-line) command line.
+
+**Print help:**
+
+```sh
+docker run -ti --rm \
+  -v `pwd`:/usr/src/ontology \
+  -w /usr/src/ontology \
+  ghcr.io/okp4/ruby-rdf:3.1.15 --help
+```
+
+**Validate ontology `my-ontology.ttl`:**
+
+```sh
+docker run -ti --rm \
+  -v `pwd`:/usr/src/ontology \
+  -w /usr/src/ontology \
+  ghcr.io/okp4/ruby-rdf:3.1.15 validate --validate my-ontology.ttl
+```
+
+**Convert `my-ontology.ttl` to `jsonld` format:**
+
+```sh
+docker run -ti --rm \
+  -v `pwd`:/usr/src/ontology \
+  -w /usr/src/ontology \
+  ghcr.io/okp4/ruby-rdf:3.1.15 serialize --output-format jsonld -o my-ontology.json my-ontology.ttl
+```


### PR DESCRIPTION
Add a ready to use image for playing with RDFs & ontologies from the command line - based on [ruby-rdf](https://github.com/ruby-rdf) tools.