### PR TITLE
Push docker image to dockerhub before publishing the readme files

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,6 +51,8 @@ jobs:
 
   prepare-readmes:
     runs-on: ubuntu-20.04
+    needs: prepare
+    if: ${{ !failure() }}
     outputs:
       matrix: ${{ steps.matrix.outputs.config }}
       any-changed: ${{ steps.changed-readmes.outputs.any_changed }}


### PR DESCRIPTION
An other PR regarding dockerhub image description.

This one to cover the new docker image case: the image needs to be on dockerhub before publishing the readme.

So run sequentially readme files uploading after publishing the images.