### PR TITLE
Add proto-gen-doc on buf-cosmos

### DIFF
--- a/dockerfiles/buf-cosmos/0.3.1/Dockerfile
+++ b/dockerfiles/buf-cosmos/0.3.1/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.19-alpine3.16 AS protoc-builder
 
 # hadolint ignore=DL4006,DL3003
 RUN apk update \
-    && apk add --no-cache curl=7.83.1-r3 make=4.3-r0 \
+    && apk add --no-cache curl=7.83.1-r3 make=4.3-r0 git\
     && wget -qO- https://github.com/regen-network/cosmos-proto/archive/refs/tags/v0.3.1.tar.gz | tar -zxv \
     && wget -qO- https://github.com/regen-network/protobuf/archive/refs/tags/v1.3.3-alpha.regen.1.tar.gz | tar -zxv \
     && cd protobuf-1.3.3-alpha.regen.1 \
@@ -10,6 +10,8 @@ RUN apk update \
     && make install \
     && cd ../cosmos-proto-0.3.1/ \
     && go install ./protoc-gen-gocosmos
+
+RUN go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
 
 FROM bufbuild/buf:1.8.0
 

--- a/dockerfiles/buf-cosmos/1.4.2/Dockerfile
+++ b/dockerfiles/buf-cosmos/1.4.2/Dockerfile
@@ -2,10 +2,12 @@ FROM golang:1.19-alpine3.16 AS protoc-builder
 
 # hadolint ignore=DL4006,DL3003
 RUN apk update \
-    && apk add --no-cache curl=7.83.1-r3 make=4.3-r0 \
+    && apk add --no-cache curl=7.83.1-r3 make=4.3-r0 git \
     && wget -qO- https://github.com/cosmos/gogoproto/archive/refs/tags/v1.4.2.tar.gz | tar -zxv \
     && cd gogoproto-1.4.2 \
     && make install
+
+RUN go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
 
 FROM bufbuild/buf:1.8.0
 


### PR DESCRIPTION
#### 📝 Description 

Add the binary [protoc-gen-doc](https://github.com/pseudomuto/protoc-gen-doc) allowing generate markdown documentation on buf build. 

Needed for this PR : https://github.com/okp4/okp4d/pull/177