### PR TITLE
docs: fix github workflow badges 🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 > 🐳 Repository for [Docker](https://www.docker.com/what-docker) configurations and images we use at [@okp4][okp4].
 
-![lint](https://img.shields.io/github/workflow/status/okp4/docker-images/Lint?label=lint&style=for-the-badge&logo=github)
-![build](https://img.shields.io/github/workflow/status/okp4/docker-images/Build?label=build&style=for-the-badge&logo=github)
-![publish](https://img.shields.io/github/workflow/status/okp4/docker-images/Publish?label=publish&style=for-the-badge&logo=github)
+![lint](https://img.shields.io/github/actions/workflow/status/okp4/docker-images/lint.yml?branch=main&label=lint&style=for-the-badge&logo=github)
+![build](https://img.shields.io/github/actions/workflow/status/okp4/docker-images/build.yml?branch=main&label=build&style=for-the-badge&logo=github)
+![publish](https://img.shields.io/github/actions/workflow/status/okp4/docker-images/publish.yml?branch=main&label=publish&style=for-the-badge&logo=github)
 [![conventional commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg?logo=conventionalcommits&style=for-the-badge)](https://conventionalcommits.org)
 [![contributor covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=for-the-badge)](https://github.com/okp4/.github/blob/main/CODE_OF_CONDUCT.md)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg?style=for-the-badge)](https://opensource.org/licenses/BSD-3-Clause)


### PR DESCRIPTION
This PR fixes github workflow badges after a breaking change on github platform. Everything is explained there : https://github.com/badges/shields/issues/8671

I took advantage of this PR to make the workflow status badges target only the `main` branch.

🤖 This PR is generated by this [script](https://gist.github.com/ad2ien/a335f9d405bce05ec6f6ad324afdd675#file-fix-action-status-badges-sh).
