### PR TITLE
⬆️ Update gogoproto for 0.47.x

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           dockerfile: Dockerfile
           recursive: true
+          verbose: true
 
       - name: Lint dockerfile (docker-lint)
         if: steps.changed-dockerfiles.outputs.any_changed == 'true'

--- a/dockerfiles/buf-cosmos/1.4.7/Dockerfile
+++ b/dockerfiles/buf-cosmos/1.4.7/Dockerfile
@@ -13,7 +13,7 @@ RUN go install github.com/cosmos/cosmos-proto/cmd/protoc-gen-go-pulsar@latest &&
 # install all gogo protobuf binaries
 RUN git clone https://github.com/cosmos/gogoproto.git
 
-WORKDIR gogoproto
+WORKDIR /go/gogoproto
 
 RUN git checkout v${GOGOPROTO_VERSION} && \
   go mod download && \

--- a/dockerfiles/buf-cosmos/1.4.7/Dockerfile
+++ b/dockerfiles/buf-cosmos/1.4.7/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.19-alpine3.16 AS protoc-builder
 
 # hadolint ignore=DL4006,DL3003
 RUN apk update \
-    && apk add --no-cache curl=7.83.1-r3 make=4.3-r0 git=2.36.2-r0 \
+    && apk add --no-cache curl=7.83.1-r6 make=4.3-r0 git=2.36.5-r0
 
 ENV GOLANG_PROTOBUF_VERSION=1.28.1
 ENV GOGOPROTO_VERSION=1.4.7

--- a/dockerfiles/buf-cosmos/1.4.7/Dockerfile
+++ b/dockerfiles/buf-cosmos/1.4.7/Dockerfile
@@ -1,0 +1,27 @@
+FROM golang:1.19-alpine3.16 AS protoc-builder
+
+# hadolint ignore=DL4006,DL3003
+RUN apk update \
+    && apk add --no-cache curl=7.83.1-r3 make=4.3-r0 git=2.36.2-r0 \
+
+ENV GOLANG_PROTOBUF_VERSION=1.28.1
+ENV GOGOPROTO_VERSION=1.4.7
+
+RUN go install github.com/cosmos/cosmos-proto/cmd/protoc-gen-go-pulsar@latest && \
+  go install google.golang.org/protobuf/cmd/protoc-gen-go@v${GOLANG_PROTOBUF_VERSION}
+
+# install all gogo protobuf binaries
+RUN git clone https://github.com/cosmos/gogoproto.git && \
+  cd gogoproto && \
+  git checkout v${GOGOPROTO_VERSION} && \
+  go mod download && \
+  make install
+
+RUN go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
+
+FROM bufbuild/buf:1.16.0
+
+RUN wget -q https://github.com/grpc-ecosystem/grpc-gateway/releases/download/v1.16.0/protoc-gen-grpc-gateway-v1.16.0-linux-x86_64 -O /usr/bin/protoc-gen-grpc-gateway \
+    && chmod +x /usr/bin/protoc-gen-grpc-gateway
+
+COPY --from=protoc-builder /go/bin/protoc-* /usr/bin/

--- a/dockerfiles/buf-cosmos/1.4.7/Dockerfile
+++ b/dockerfiles/buf-cosmos/1.4.7/Dockerfile
@@ -11,9 +11,11 @@ RUN go install github.com/cosmos/cosmos-proto/cmd/protoc-gen-go-pulsar@latest &&
   go install google.golang.org/protobuf/cmd/protoc-gen-go@v${GOLANG_PROTOBUF_VERSION}
 
 # install all gogo protobuf binaries
-RUN git clone https://github.com/cosmos/gogoproto.git && \
-  cd gogoproto && \
-  git checkout v${GOGOPROTO_VERSION} && \
+RUN git clone https://github.com/cosmos/gogoproto.git
+
+WORKDIR gogoproto
+
+RUN git checkout v${GOGOPROTO_VERSION} && \
   go mod download && \
   make install
 


### PR DESCRIPTION
### 📝 Purpose

This PR add a new Dockerfile that allow generate go protobuf file for the okp4 chain binary. This new version is used for the new comos-sdk version 0.47.x. 

### Dependencies 

- New version of gogoproto : v1.4.7
- New buf version 1.16
- New proto-gen-doc 1.28.1

Needed for update cosmos sdk 0.47.x : https://github.com/okp4/okp4d/pull/282