### PR TITLE
🖥️ Allow choose platforms for build Dockerfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,8 @@ jobs:
               APATH=$(dirname ${DOCKERFILE})
               VERSION=$(basename ${APATH})
               NAME=$(basename $(dirname $APATH))
-              CONFIG="${CONFIG:+${CONFIG}, }{\"path\": \"${APATH}\", \"version\": \"${VERSION}\", \"name\": \"${NAME}\"}"
+              PLATFORMS=$(cat ${APATH}/.platforms || echo "linux/amd64")
+              CONFIG="${CONFIG:+${CONFIG}, }{\"path\": \"${APATH}\", \"version\": \"${VERSION}\", \"name\": \"${NAME}\", \"platforms\": \"${PLATFORMS}\"}"
           done
           echo "config=[${CONFIG}]" >> $GITHUB_OUTPUT
 
@@ -71,6 +72,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: ${{ matrix.context.path }}
+          platforms: ${{ matrix.context.platforms }}
           push: false
           tags: |
             "ghcr.io/${{ needs.prepare.outputs.repository_owner }}/${{ matrix.context.name }}:${{ matrix.context.version }}-${{ needs.prepare.outputs.date_stamp }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,8 @@ jobs:
               APATH=$(dirname ${DOCKERFILE})
               VERSION=$(basename ${APATH})
               NAME=$(basename $(dirname $APATH))
-              CONFIG="${CONFIG:+${CONFIG}, }{\"path\": \"${APATH}\", \"version\": \"${VERSION}\", \"name\": \"${NAME}\"}"
+              PLATFORMS=$(cat ${APATH}/.platforms || echo "linux/amd64")
+              CONFIG="${CONFIG:+${CONFIG}, }{\"path\": \"${APATH}\", \"version\": \"${VERSION}\", \"name\": \"${NAME}\", \"platforms\": \"${PLATFORMS}\"}"
           done
           echo "config=[${CONFIG}]" >> $GITHUB_OUTPUT
 
@@ -118,6 +119,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: ${{ matrix.context.path }}
+          platforms: ${{ matrix.context.platforms }}
           push: true
           tags: |
             "ghcr.io/${{ needs.prepare.outputs.repository_owner }}/${{ matrix.context.name }}:${{ matrix.context.version }}-${{ needs.prepare.outputs.date_stamp }}"

--- a/dockerfiles/buf-cosmos/1.4.7/.platforms
+++ b/dockerfiles/buf-cosmos/1.4.7/.platforms
@@ -1,0 +1,1 @@
+linux/amd64,linux/arm64

--- a/dockerfiles/buf-cosmos/1.4.7/Dockerfile
+++ b/dockerfiles/buf-cosmos/1.4.7/Dockerfile
@@ -7,7 +7,7 @@ RUN apk update \
 ENV GOLANG_PROTOBUF_VERSION=1.28.1
 ENV GOGOPROTO_VERSION=1.4.7
 
-RUN go install github.com/cosmos/cosmos-proto/cmd/protoc-gen-go-pulsar@latest && \
+RUN go install github.com/cosmos/cosmos-proto/cmd/protoc-gen-go-pulsar@760914ff5b20d0420b15c6ce66be8c8808ae40c2 && \
   go install google.golang.org/protobuf/cmd/protoc-gen-go@v${GOLANG_PROTOBUF_VERSION}
 
 RUN git clone https://github.com/cosmos/gogoproto.git

--- a/dockerfiles/buf-cosmos/1.4.7/Dockerfile
+++ b/dockerfiles/buf-cosmos/1.4.7/Dockerfile
@@ -10,7 +10,6 @@ ENV GOGOPROTO_VERSION=1.4.7
 RUN go install github.com/cosmos/cosmos-proto/cmd/protoc-gen-go-pulsar@latest && \
   go install google.golang.org/protobuf/cmd/protoc-gen-go@v${GOLANG_PROTOBUF_VERSION}
 
-# install all gogo protobuf binaries
 RUN git clone https://github.com/cosmos/gogoproto.git
 
 WORKDIR /go/gogoproto


### PR DESCRIPTION
### 📝 Purpose

Add new `.platforms` file that contains setting used to build Dockerfile on configured platform. 

If no `.platforms` file set at the Dockerfile path, the default `linux/amd64` platform is used.