### PR TITLE
feat(ruby-rdf): add ruby-rdf v3.3.1

### DIFF
--- a/dockerfiles/ruby-rdf/3.3.1/Dockerfile
+++ b/dockerfiles/ruby-rdf/3.3.1/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:3.2.2-alpine3.18
+
+RUN gem install \
+    rdf:3.3.1 \
+    rdf-turtle:3.3.0 \
+    rdf-n3:3.3.0 \
+    rdf-json:3.3.0 \
+    rdf-rdfxml:3.3.0 \
+    json-ld:3.3.0 \
+    sparql:3.3.0
+
+
+ENTRYPOINT ["rdf"]


### PR DESCRIPTION
Self explantory.

Adds the [ruby-rdf v3.3.1 release](https://github.com/ruby-rdf/rdf/releases/tag/3.3.1) image, running with [Ruby v3.2.2](https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-2-2-released/) under [alpine v3.18](https://hub.docker.com/layers/library/ruby/3.2.2-alpine3.18/images/sha256-f66e5c35638786e9490fac8ea929a5f84104f302a3d92b728c85181b46290bbf?context=explore).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a Docker container setup for the Ruby application with support for various RDF formats and SPARQL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->